### PR TITLE
aql search delete method added

### DIFF
--- a/ariel.go
+++ b/ariel.go
@@ -137,3 +137,19 @@ func (a *ArielService) WaitForSearchID(ctx context.Context, searchID string, sta
 		}
 	}
 }
+
+// DeleteSearch returns a search status that has been deleted and the error.
+func (a *ArielService) DeleteSearch(ctx context.Context, searchID string) (string, error) {
+	req, err := a.client.NewRequest(http.MethodDelete, fmt.Sprintf("%s/%s", arielSearchAPIPrefix, searchID), nil)
+	if err != nil {
+		return "", err
+	}
+
+	var s Search
+	_, err = a.client.Do(ctx, req, &s)
+	if err != nil {
+		return "", err
+	}
+
+	return *s.Status, nil
+}


### PR DESCRIPTION
It is necessary to optimize qradar system
If the search results and the search itself are no longer needed

Documentation:
_Deletes an Ariel search. This discards any results that were collected and stops the
search if it is currently processing. This search is deleted regardless of whether the
results were saved._